### PR TITLE
Feature add patch method

### DIFF
--- a/lib/mumukit/core/module.rb
+++ b/lib/mumukit/core/module.rb
@@ -5,4 +5,12 @@ class Module
       raise message
     end
   end
+
+  def patch(method_name, &block)
+    method_proc = instance_method method_name
+
+    define_method method_name do |*args|
+      block.call(*args, method_proc.bind(self))
+    end
+  end
 end

--- a/spec/mumukit/module_spec.rb
+++ b/spec/mumukit/module_spec.rb
@@ -6,9 +6,26 @@ end
 
 class TestClass
   required :baz
+
+  def patch_me(some_param)
+    "some_param: #{some_param}, "
+  end
+end
+
+class TestClass
+  patch :patch_me do |some_param, some_other_param, ultra|
+    ultra.call(some_param) + "some_other_param: #{some_other_param}"
+  end
 end
 
 describe Module do
-  it { expect { TestClass.new.baz }.to raise_error 'You need to implement method baz' }
-  it { expect { Object.new.extend(TestModule).foo }.to raise_error 'You need to implement method foo' }
+
+  describe '.required' do
+    it { expect { TestClass.new.baz }.to raise_error 'You need to implement method baz' }
+    it { expect { Object.new.extend(TestModule).foo }.to raise_error 'You need to implement method foo' }
+  end
+
+  describe '.patch' do
+    it { expect(TestClass.new.patch_me('123', 'abc')).to eq('some_param: 123, some_other_param: abc') }
+  end
 end

--- a/spec/mumukit/module_spec.rb
+++ b/spec/mumukit/module_spec.rb
@@ -13,8 +13,8 @@ class TestClass
 end
 
 class TestClass
-  patch :patch_me do |some_param, some_other_param, ultra|
-    ultra.call(some_param) + "some_other_param: #{some_other_param}"
+  patch :patch_me do |some_param, some_other_param, hyper|
+    hyper.call(some_param) + "some_other_param: #{some_other_param}"
   end
 end
 


### PR DESCRIPTION
Adding a method to patch other methods in the same class/module.

That way we don't have to recur to defining an alias_method and calling the old implementation within the new one.

Every patched method receives as its last param a block containing the previous definition of the method.