### PR TITLE
Feature rewrite

### DIFF
--- a/lib/mumukit/core/module.rb
+++ b/lib/mumukit/core/module.rb
@@ -90,7 +90,7 @@ class Module
   end
 
   def rewrite(selector, &block)
-    raise "method #{selector} was not previously defined here" unless instance_methods(false).include?(selector)
+    raise "method #{selector} was not previously defined here" unless method_defined?(selector)
     define_method selector, &block
   end
 end

--- a/lib/mumukit/core/module.rb
+++ b/lib/mumukit/core/module.rb
@@ -88,4 +88,9 @@ class Module
       this.instance_variable_get(attr_name) || this.instance_variable_set(attr_name, hyper.call)
     end
   end
+
+  def rewrite(selector, &block)
+    raise "method #{selector} was not previously defined here" unless instance_methods(false).include?(selector)
+    define_method selector, &block
+  end
 end

--- a/spec/mumukit/module_spec.rb
+++ b/spec/mumukit/module_spec.rb
@@ -104,9 +104,10 @@ describe Module do
   describe '.rewrite' do
     before { SomeChildClass.rewrite(:foobar) { 'something else' } }
 
-    it { expect { SomeChildClass.rewrite(:foo) {} }.to raise_error 'method foo was not previously defined here' }
-    it { expect { SomeChildClass.rewrite(:bar) {} }.to raise_error 'method bar was not previously defined here' }
+    it { expect { SomeChildClass.rewrite(:foo) {} }.to_not raise_error 'method foo was not previously defined here' }
+    it { expect { SomeChildClass.rewrite(:bar) {} }.to_not raise_error 'method bar was not previously defined here' }
     it { expect { SomeChildClass.rewrite(:baz) {} }.to_not raise_error }
+    it { expect { SomeChildClass.rewrite(:foobaz) {} }.to raise_error }
     it { expect(SomeChildClass.new.foobar).to eq 'something else' }
   end
 end

--- a/spec/mumukit/module_spec.rb
+++ b/spec/mumukit/module_spec.rb
@@ -53,8 +53,28 @@ class TestClass
   end
 end
 
-describe Module do
+module SomeModule
+  def foo
+  end
+end
 
+class SomeParentClass
+  def bar
+  end
+end
+
+class SomeChildClass < SomeParentClass
+  include SomeModule
+
+  def baz
+  end
+
+  def foobar
+    'something'
+  end
+end
+
+describe Module do
   describe '.required' do
     it { expect { TestClass.new.baz }.to raise_error 'You need to implement method baz' }
     it { expect { Object.new.extend(TestModule).foo }.to raise_error 'You need to implement method foo' }
@@ -79,5 +99,14 @@ describe Module do
 
     it { expect(object.a_number).to eq 11 }
     it { expect(object.another_number).to eq 21 }
+  end
+
+  describe '.rewrite' do
+    before { SomeChildClass.rewrite(:foobar) { 'something else' } }
+
+    it { expect { SomeChildClass.rewrite(:foo) {} }.to raise_error 'method foo was not previously defined here' }
+    it { expect { SomeChildClass.rewrite(:bar) {} }.to raise_error 'method bar was not previously defined here' }
+    it { expect { SomeChildClass.rewrite(:baz) {} }.to_not raise_error }
+    it { expect(SomeChildClass.new.foobar).to eq 'something else' }
   end
 end


### PR DESCRIPTION
Changed behavior as discussed with @luchotc.

`rewrite` will now fail only when method is not defined in ancestry at all.
If it is defined in a superclass or included mixin, it will _not_ raise an error.